### PR TITLE
Create subjectId without base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ This example demonstrates how to parse a turtle string into an AclDoc object, th
 ```javascript
 const SolidAclParser = require('SolicAclParser')
 
-const webId = 'https://solid.example.org/profile/card#me'
+const webId = 'https://pod.example.org/profile/card#me'
 const aclUrl = 'https://pod.example.org/private/file.ext.acl'
 const fileUrl = 'https://pod.example.org/private/file.ext'
 const turtle = `
 @prefix   acl:  <http://www.w3.org/ns/auth/acl#>.
 @prefix  foaf:  <http://xmlns.com/foaf/0.1/>.
 
-<#authorization2>
+<#Read-0>
     a               acl:Authorization;
     acl:agentClass  foaf:Agent;                               # everyone
     acl:mode        acl:Read;                                 # has Read-only access
@@ -52,12 +52,12 @@ Output turtle
 @prefix acl: <http://www.w3.org/ns/auth/acl#>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 
-<https://pod.example.org/private/file.ext.acl#authorization2> a acl:Authorization;
+<#Read-0> a acl:Authorization;
     acl:agentClass foaf:Agent;
-    acl:accessTo <https://pod.example.org/private/file.ext>;
+    acl:accessTo <./file.ext>;
     acl:mode acl:Read.
-<solid-acl-parser-rule-0> a acl:Authorization;
-    acl:agent <https://solid.example.org/profile/card#me>;
-    acl:accessTo <https://pod.example.org/private/file.ext>;
+<#WriteControl-0> a acl:Authorization;
+    acl:agent </profile/card#me>;
+    acl:accessTo <./file.ext>;
     acl:mode acl:Write, acl:Control.
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,14 +38,14 @@ This example demonstrates how to parse a turtle string into an AclDoc object, th
 *Tip: You can copy paste all complete example like this [here](./run.html ':ignore') to run it in CodePen*
 
 ```javascript
-const webId = 'https://solid.example.org/profile/card#me'
+const webId = 'https://pod.example.org/profile/card#me'
 const aclUrl = 'https://pod.example.org/private/file.ext.acl'
 const fileUrl = 'https://pod.example.org/private/file.ext'
 const turtle = `
 @prefix   acl:  <http://www.w3.org/ns/auth/acl#>.
 @prefix  foaf:  <http://xmlns.com/foaf/0.1/>.
 
-<#authorization2>
+<#Read-0>
     a               acl:Authorization;
     acl:agentClass  foaf:Agent;                               # everyone
     acl:mode        acl:Read;                                 # has Read-only access
@@ -74,13 +74,13 @@ Output turtle
 @prefix acl: <http://www.w3.org/ns/auth/acl#>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 
-<https://pod.example.org/private/file.ext.acl#authorization2> a acl:Authorization;
+<#Read-0> a acl:Authorization;
     acl:agentClass foaf:Agent;
-    acl:accessTo <https://pod.example.org/private/file.ext>;
+    acl:accessTo <./file.ext>;
     acl:mode acl:Read.
-<https://pod.example.org/private/file.ext#solid-acl-parser-rule-0> a acl:Authorization;
-    acl:agent <https://solid.example.org/profile/card#me>;
-    acl:accessTo <https://pod.example.org/private/file.ext>;
+<#WriteControl-0> a acl:Authorization;
+    acl:agent </profile/card#me>;
+    acl:accessTo <./file.ext>;
     acl:mode acl:Write, acl:Control.
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-acl-parser",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2352,6 +2352,11 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
     },
+    "@types/url-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw=="
+    },
     "@types/yargs": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
@@ -8094,9 +8099,9 @@
       "dev": true
     },
     "n3": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.3.3.tgz",
-      "integrity": "sha512-ZDUJFB9CpnPuWJA75ONOukLKFV762o5Qhl6SvqjvDb+NP6x9WJ/b1L3GUtXXkbwRTCdVVQfmC/vDhgKs7uBR5w=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.3.4.tgz",
+      "integrity": "sha512-Eu5EVYGncuwiTlOV1J6p3OFBNSfI84D+fW0o8o5s2aRowO3yRcM4SvqPTOKzCCJutRvaXP0J9GIzwrP6tINm2Q=="
     },
     "nan": {
       "version": "2.14.0",
@@ -9087,6 +9092,11 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "querystringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -9400,6 +9410,11 @@
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
       }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.11.1",
@@ -10924,6 +10939,15 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
+      }
+    },
+    "url-parse": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "url-parse-lax": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-acl-parser",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "keywords": [
     "solid",
     "acl",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
   "dependencies": {
     "@babel/runtime-corejs3": "^7.7.4",
     "@types/n3": "^1.1.1",
+    "@types/url-parse": "^1.4.3",
     "core-js": "^3.4.5",
-    "n3": "^1.3.3"
+    "n3": "^1.3.4",
+    "url-parse": "^1.4.7"
   },
   "standard": {
     "parser": "@typescript-eslint/parser",

--- a/src/AclDoc.ts
+++ b/src/AclDoc.ts
@@ -302,12 +302,12 @@ class AclDoc {
 
   _defaultSubjectIdForRule (rule: AclRule) {
     let id = '#'
-    if (rule.default || rule.defaultForNew)
-      id += 'Default'
     id += Object.entries(permissionLinks)
       .filter(([name, permission]) => rule.permissions.has(permission))
       .map(([name]) => name[0] + name.substr(1).toLowerCase())
       .join('')
+    if (rule.default || rule.defaultForNew)
+      id += 'Default'
     return id + '-'
   }
 }

--- a/src/AclDoc.ts
+++ b/src/AclDoc.ts
@@ -286,14 +286,21 @@ class AclDoc {
     let index = Number(digitMatches[0]) // Last positive number; 0 if not ending with number
     base = base.replace(/[\d]*$/, '')
 
-    while (this.rules.hasOwnProperty(base + index)) {
+    while (this._containsSimilarSubjectId(base + index)) {
       index++
     }
     return base + index
   }
 
+  _containsSimilarSubjectId(subjId: string) {
+    subjId = subjId.includes('#') ? subjId.substr(subjId.lastIndexOf('#')) : subjId
+    return Object.keys(this.rules)
+      .map(id => id.includes('#') ? id.substr(id.lastIndexOf('#')) : id)
+      .some(id => id === subjId)
+  }
+
   get _defaultSubjectId () {
-    return this.accessTo + '#solid-acl-parser-rule-'
+    return '#solid-acl-parser-rule-'
   }
 }
 

--- a/src/AclDoc.ts
+++ b/src/AclDoc.ts
@@ -2,7 +2,7 @@ import Agents, { AgentsCastable } from './Agents'
 import Permissions, { PermissionsCastable, permissionString, permissionLinks } from './Permissions'
 import AclRule from './AclRule'
 import { iterableEquals } from './utils'
-import { Quad } from 'n3';
+import { Quad } from 'n3'
 
 /**
  * @module AclDoc
@@ -26,7 +26,7 @@ class AclDoc {
   public readonly strict: boolean
   public rules: Record<string, AclRule>
   public otherQuads: Quad[]
-  
+
   constructor ({ accessTo, strict = true }: AclDocOptions) {
     this.accessTo = accessTo
     this.strict = strict
@@ -62,7 +62,7 @@ class AclDoc {
   addDefaultRule (firstVal: AclRule|PermissionsCastable, agents?: Agents, options: AddRuleOptions = {}) {
     const rule = this._ruleFromArgs(firstVal, agents)
     rule.default = this.accessTo
-    
+
     return this.addRule(rule, undefined, options)
   }
 
@@ -293,11 +293,11 @@ class AclDoc {
     return base + index
   }
 
-  _containsSubjectId(subjectId: string) {
+  _containsSubjectId (subjectId: string) {
     return this.rules.hasOwnProperty(this._normalizedSubectId(subjectId))
   }
 
-  _normalizedSubectId(subjectId: string) {
+  _normalizedSubectId (subjectId: string) {
     if (!subjectId.startsWith(this.accessTo)) {
       return subjectId
     }
@@ -310,8 +310,7 @@ class AclDoc {
       .filter(([name, permission]) => rule.permissions.has(permission))
       .map(([name]) => name[0] + name.substr(1).toLowerCase())
       .join('')
-    if (rule.default || rule.defaultForNew)
-      id += 'Default'
+    if (rule.default || rule.defaultForNew) { id += 'Default' }
     return id + '-'
   }
 }

--- a/src/AclDoc.ts
+++ b/src/AclDoc.ts
@@ -49,7 +49,7 @@ class AclDoc {
    */
   addRule (firstVal: AclRule|PermissionsCastable, agents?: Agents, { subjectId }: AddRuleOptions = {}) {
     const rule = this._ruleFromArgs(firstVal, agents)
-    subjectId = subjectId || this._getNewSubjectId(rule)
+    subjectId = this._normalizedSubectId(subjectId || this._getNewSubjectId(rule))
     this.rules[subjectId] = rule
 
     return this
@@ -102,7 +102,7 @@ class AclDoc {
    * @description Get the rule with this subject id
    */
   getRuleBySubjectId (subjectId: string): AclRule|undefined {
-    return this.rules[subjectId]
+    return this.rules[this._normalizedSubectId(subjectId)]
   }
 
   /**
@@ -287,17 +287,21 @@ class AclDoc {
     let index = Number(digitMatches[0]) // Last positive number; 0 if not ending with number
     base = base.replace(/[\d]*$/, '')
 
-    while (this._containsSimilarSubjectId(base + index)) {
+    while (this._containsSubjectId(base + index)) {
       index++
     }
     return base + index
   }
 
-  _containsSimilarSubjectId(subjId: string) {
-    subjId = subjId.includes('#') ? subjId.substr(subjId.lastIndexOf('#')) : subjId
-    return Object.keys(this.rules)
-      .map(id => id.includes('#') ? id.substr(id.lastIndexOf('#')) : id)
-      .some(id => id === subjId)
+  _containsSubjectId(subjectId: string) {
+    return this.rules.hasOwnProperty(this._normalizedSubectId(subjectId))
+  }
+
+  _normalizedSubectId(subjectId: string) {
+    if (!subjectId.startsWith(this.accessTo)) {
+      return subjectId
+    }
+    return subjectId.includes('#') ? subjectId.substr(subjectId.lastIndexOf('#')) : subjectId
   }
 
   _defaultSubjectIdForRule (rule: AclRule) {

--- a/src/AclParser.ts
+++ b/src/AclParser.ts
@@ -3,7 +3,7 @@ import AclDoc from './AclDoc'
 import prefixes from './prefixes'
 import AclRule from './AclRule'
 import { parseTurtle, makeRelativeIfPossible } from './utils'
-import { permissionString } from './Permissions';
+import { permissionString } from './Permissions'
 
 /**
  * @module AclParser
@@ -58,13 +58,12 @@ class AclParser {
   private readonly parser: N3.N3Parser
   private readonly accessTo: string
   private readonly aclUrl: string
-  
+
   constructor ({ fileUrl, aclUrl }: AclParserOptions) {
     this.parser = new N3.Parser({ baseIRI: aclUrl })
     this.accessTo = fileUrl
     this.aclUrl = aclUrl
   }
-
 
   async turtleToAclDoc (aclTurtle: string) {
     const data = await parseTurtle(this.parser, aclTurtle)

--- a/src/AclRule.ts
+++ b/src/AclRule.ts
@@ -1,7 +1,7 @@
 import { Quad } from 'n3'
 import Permissions, { PermissionsCastable } from './Permissions'
 import Agents, { AgentsCastable } from './Agents'
-import { iterableEquals, iterableIncludesIterable } from './utils'
+import { iterableEquals } from './utils'
 
 /**
  * @module AclRule
@@ -13,7 +13,6 @@ interface AclRuleOptions {
   default?: string
   defaultForNew?: string
 }
-
 
 /**
  * @description Groups together permissions, agents and other relevant information for an acl rule
@@ -58,7 +57,7 @@ class AclRule {
   equals (other: AclRule) {
     return other instanceof AclRule &&
       iterableEquals(this.otherQuads, other.otherQuads) &&
-      this.accessTo == other.accessTo &&
+      this.accessTo === other.accessTo &&
       this.permissions.equals(other.permissions) &&
       this.agents.equals(other.agents) &&
       this.default === other.default &&
@@ -105,9 +104,10 @@ class AclRule {
     const rules: AclRule[] = []
     const firstOptions = AclRule._getOptions(first)
 
-    if ((first.default && first.default !== second.default)
-        || first.accessTo !== second.accessTo)
+    if ((first.default && first.default !== second.default) ||
+        first.accessTo !== second.accessTo) {
       return [first.clone()]
+    }
 
     // Add rule for all unaffected agents
     // e.g. AclRule([READ, WRITE], ['web', 'id']) - AclRule([READ, WRITE], 'web') = AclRule([READ, WRITE], 'id')
@@ -123,7 +123,7 @@ class AclRule {
     return rules.filter(rule => !rule.hasNoEffect())
   }
 
-  static _getOptions(rule: AclRule) {
+  static _getOptions (rule: AclRule) {
     const options: AclRuleOptions = {}
     options.otherQuads = rule.otherQuads
     options.default = rule.default

--- a/src/Permissions.ts
+++ b/src/Permissions.ts
@@ -10,7 +10,7 @@ export const permissionLinks = {
   WRITE: `${prefixes.acl}Write`,
   APPEND: `${prefixes.acl}Append`,
   CONTROL: `${prefixes.acl}Control`
-} as Record<string, permissionString> 
+} as Record<string, permissionString>
 
 export type permissionString = 'http://www.w3.org/ns/auth/acl#Read' |
   'http://www.w3.org/ns/auth/acl#Write' |

--- a/src/Permissions.ts
+++ b/src/Permissions.ts
@@ -5,7 +5,7 @@ import { iterableEquals } from './utils'
  * @module Permissions
  */
 
-const permissionLinks = {
+export const permissionLinks = {
   READ: `${prefixes.acl}Read`,
   WRITE: `${prefixes.acl}Write`,
   APPEND: `${prefixes.acl}Append`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,12 +58,15 @@ export function parseTurtle (parser: N3Parser, turtle: string) {
 export function makeRelativeIfPossible(base: string, url: string) {
   const urlObj = new URL(url)
   const baseObj = new URL(base)
+
   if (urlObj.origin !== baseObj.origin)
       return url
 
-  let relPath = relative(dirname(baseObj.pathname), urlObj.pathname)  
-  if (!relPath.startsWith('.')) // path.relative resolves with empty string for equal strings
-    relPath = `./${relPath}`
+  const basePath = baseObj.pathname.endsWith('/') ? baseObj.pathname : dirname(baseObj.pathname)
+  const relPath = relative(basePath, urlObj.pathname)
+  const suffix = urlObj.query + urlObj.hash
 
-  return `${relPath}${urlObj.query}${urlObj.hash}`
+  return relPath.startsWith('../') ?
+    urlObj.pathname + suffix
+    : `./${relPath}${suffix}`
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,18 +55,19 @@ export function parseTurtle (parser: N3Parser, turtle: string) {
   })
 }
 
-export function makeRelativeIfPossible(base: string, url: string) {
+export function makeRelativeIfPossible (base: string, url: string) {
   const urlObj = new URL(url)
   const baseObj = new URL(base)
 
-  if (urlObj.origin !== baseObj.origin)
-      return url
+  if (urlObj.origin !== baseObj.origin) {
+    return url
+  }
 
   const basePath = baseObj.pathname.endsWith('/') ? baseObj.pathname : dirname(baseObj.pathname)
   const relPath = relative(basePath, urlObj.pathname)
   const suffix = urlObj.query + urlObj.hash
 
-  return relPath.startsWith('../') ?
-    urlObj.pathname + suffix
+  return relPath.startsWith('../')
+    ? urlObj.pathname + suffix
     : `./${relPath}${suffix}`
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import { N3Parser, Quad } from 'n3'
+import URL from 'url-parse'
+import { relative, dirname } from 'path'
 
 type Iterable<T=any> = Array<T>|Set<T>
 
@@ -51,4 +53,17 @@ export function parseTurtle (parser: N3Parser, turtle: string) {
       data[subjectId].push(quad)
     })
   })
+}
+
+export function makeRelativeIfPossible(base: string, url: string) {
+  const urlObj = new URL(url)
+  const baseObj = new URL(base)
+  if (urlObj.origin !== baseObj.origin)
+      return url
+
+  let relPath = relative(dirname(baseObj.pathname), urlObj.pathname)  
+  if (!relPath.startsWith('.')) // path.relative resolves with empty string for equal strings
+    relPath = `./${relPath}`
+
+  return `${relPath}${urlObj.query}${urlObj.hash}`
 }

--- a/tests/parse/samples.js
+++ b/tests/parse/samples.js
@@ -61,7 +61,7 @@ const samples = [
                     acl:Write;
     acl:agentGroup  <https://alice.example.com/work-groups#Accounting>;
     acl:agentGroup  <https://alice.example.com/work-groups#Management>.`,
-    aclUrl: 'https://alice.databox.me/docs/shared-file1.acl',
+    aclUrl: 'https://alice.example.com/docs/shared-file1.acl',
     fileUrl: 'https://alice.example.com/docs/shared-file1',
     getAclDoc () {
       const doc = new AclDoc({ accessTo: this.fileUrl })

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,22 @@
+import { makeRelativeIfPossible } from '../src/utils'
+
+const origin = 'https://example.org'
+const base = `${origin}/foo/`
+
+describe('makeRelativeIfPossible', () => {
+    test('returns absolute url if different origin', () => {
+        const url = 'https://other.example.org/foo/?test=true#abc'
+        expect(makeRelativeIfPossible(base, url)).toBe(url)
+    })
+    test('returns path from root if different folder', () => {
+        const path = '/other/'
+        expect(makeRelativeIfPossible(base, `${origin}${path}`)).toBe(path)
+    })
+    test('returns ./ if it is the same folder', () => {
+        expect(makeRelativeIfPossible(base, base)).toBe('./')
+    })
+    test('returns relative path if it is a file in the folder', () => {
+        const fileName = 'file.ext'
+        expect(makeRelativeIfPossible(base, `${base}${fileName}`)).toBe(`./${fileName}`)
+    })
+})


### PR DESCRIPTION
Previously the subjectId in AclDoc was created using `this.accessTo + '#solid-acl-parser-rule-'`, now it uses `'#DefaultRead-'`. This makes it automatically relative to the file in which it is stored and more readable.

The check that no similar rule exists was enhanced (If `pod.example.org/foo.acl#solid-acl-parser-rule-0` exists it won't create `#solid-acl-parser-rule-0` as this could resolve to the same subjectId. Instead it will use `#solid-acl-parser-rule-1`)

If possible it will use relative paths instead of absolute urls for accessTo, webIds, groups and defaults.

Fixes #2 
Fixes #4 
Fixes #5 